### PR TITLE
Fix name displayed in the Add/Remove Programs Control Panel applet

### DIFF
--- a/scripts/windows/windows-installer.iss
+++ b/scripts/windows/windows-installer.iss
@@ -9,6 +9,7 @@ DefaultDirName={userpf}\Flowkeeper
 DefaultGroupName=Flowkeeper
 SetupIconFile=res\flowkeeper.ico
 PrivilegesRequired=lowest
+UninstallDisplayName=Flowkeeper
 SourceDir=..\..
 OutputDir=dist
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ffa06c0d-c0ab-4632-b6a1-eb0ed6f24b90)


This PR changes the name shown in uninstall apps settings from "Flowkeeper version { version-number }" to "Flowkeeper"

Please ignore this PR if the name is intended