### PR TITLE
Fix drag and drop on wayland and remove ghost rows after moving workitems

### DIFF
--- a/src/fk/qt/abstract_drop_model.py
+++ b/src/fk/qt/abstract_drop_model.py
@@ -65,10 +65,10 @@ class AbstractDropModel(QStandardItemModel):
         self.dragging = None
 
     def supportedDropActions(self) -> Qt.DropAction:
-        return Qt.DropAction.LinkAction
+        return Qt.DropAction.MoveAction
 
     def supportedDragActions(self) -> Qt.DropAction:
-        return Qt.DropAction.LinkAction
+        return Qt.DropAction.MoveAction
 
     def move_drop_placeholder(self, index: QModelIndex | None):
         if index is None:

--- a/src/fk/qt/workitem_model.py
+++ b/src/fk/qt/workitem_model.py
@@ -449,6 +449,9 @@ class WorkitemModel(AbstractDropModel):
         elif self._workitem_belongs_here(workitem):   # We can only drop workitems on backlogs, not tags
             # Moved in here
             self._add_workitem(workitem)
+        # We need to do this because when dragging and dropping a work item onto a backlog, the
+        # drag and drop succeeds but leaves a blank row in WorkItemTableView
+        self.load(self._backlog_or_tag)
 
     def _workitem_changed(self, workitem: Workitem, **kwargs) -> None:
         for i in range(self.rowCount()):


### PR DESCRIPTION
Fixes #223 

I had to change `Qt.DropAction.LinkAction` to `Qt.DropAction.MoveAction` because wayland doesn't support `Qt.DropAction.LinkAction` as seen [here](https://github.com/qt/qtbase/blob/593628750a0f17e8ff7cd7ef231fb225549ca2f6/src/plugins/platforms/wayland/qwaylanddatadevice.cpp#L371)

After using `Qt.DropAction.MoveAction` blank rows were being left after dragging and dropping a workitem onto a backlog so I had to call `self.load(self._backlog_or_tag)` inside of `_workitem_moved()` of `src/fk/qt/workitem_model.py`